### PR TITLE
Switch from componentWillMount to constructor

### DIFF
--- a/modules/Media.js
+++ b/modules/Media.js
@@ -28,7 +28,8 @@ class Media extends React.Component {
     }
   };
 
-  componentWillMount() {
+  constructor(props) {
+    super(props);
     if (typeof window !== 'object') return;
 
     const targetWindow = this.props.targetWindow || window;


### PR DESCRIPTION
Prevents warning on React 16 strict mode

Even though the warning suggests to replace it with `componentDidMount`, opted to replace it with `constructor` instead so that it is run before the component mounts, just like `componentWillMount`

``Warning: Unsafe lifecycle methods were found within a strict-mode tree:
    in Provider (at index.js:15)

componentWillMount: Please update the following components to use componentDidMount instead: Media

Learn more about this warning here:
https://fb.me/react-strict-mode-warnings```
